### PR TITLE
transactional미사용으로 인한 member Entity의 authorities eager문제 해결이 완료됨.

### DIFF
--- a/src/main/java/com/ll/medium/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/medium/domain/member/member/entity/Member.java
@@ -32,7 +32,7 @@ public class Member extends BaseEntity {
     @Email
     private String memberEmail;
 
-    @ElementCollection(fetch = FetchType.EAGER) // Todo eager말고 다른 방안은 없을까?? 간단해서 eager를 쓰긴했으나;
+    @ElementCollection(fetch = FetchType.LAZY) // Todo eager말고 다른 방안은 없을까?? 간단해서 eager를 쓰긴했으나;
     @CollectionTable(name = "member_authorities", joinColumns = @JoinColumn(name = "member_id"))
     @Column(name = "authority")
     private List<String> memberAuthorities;


### PR DESCRIPTION
데이터베이스를 수정하는 메소드에 transactional을 사용하지 않아 발생하던 문제였던 member와 member authorities테이블 연결 문제를 해결함.
Transactional을 사용하지 않았을 때, member를 생성한 후에 테이블에서 authorities에 대한 테이블을 불러오지 못하던 문제점이 있었으나, Transactional사용으로 문제가 해결됨.